### PR TITLE
add missing error handling

### DIFF
--- a/client.go
+++ b/client.go
@@ -45,7 +45,10 @@ func (c *Client) GetControllerCount() (int, error) {
 		return 0, err
 	}
 
-	message, _ := c.readMessage()
+	message, err := c.readMessage()
+	if err != nil {
+		return 0, err
+	}
 	count := int(binary.LittleEndian.Uint32(message))
 
 	return count, nil
@@ -57,7 +60,10 @@ func (c *Client) GetDeviceController(deviceID int) (Device, error) {
 	if err := c.sendMessage(commandRequestControllerData, deviceID, nil); err != nil {
 		return Device{}, err
 	}
-	message, _ := c.readMessage()
+	message, err := c.readMessage()
+	if err != nil {
+		return Device{}, err
+	}
 
 	d, err := readDevice(message)
 	if err != nil {
@@ -141,9 +147,6 @@ func (c *Client) sendMessage(command, deviceID int, buffer *bytes.Buffer) error 
 	}
 
 	_, err := c.clientSock.Write(header.Bytes())
-	if err != nil {
-		return err
-	}
 
 	return err
 }
@@ -159,5 +162,5 @@ func (c *Client) readMessage() ([]byte, error) {
 	buf = make([]byte, header.length)
 	_, err = c.clientSock.Read(buf)
 
-	return buf, nil
+	return buf, err
 }


### PR DESCRIPTION
I encountered panics when trying to make requests to OpenRGB early.
Here is example output on `GetControllerCount()` call with additional, not handled error debug log
```
message: []byte(nil)
err: read tcp 127.0.0.1:42812->127.0.0.1:25670: read: connection reset by peer

runtime error: index out of range [3] with length 0
goroutine 91 [running]:
encoding/binary.littleEndian.Uint32(...)
/home/pi/bin/go/src/encoding/binary/binary.go:64
github.com/realbucksavage/openrgb-go.(*Client).GetControllerCount(0x4000154690?)
/home/pi/go/pkg/mod/github.com/realbucksavage/openrgb-go@v0.0.0-20200814141546-d778d7774164/client.go:54 +0x134
```
I added missing error handling, as well as in some other possible places.