### PR TITLE
Send the proper command code for UpdateZoneLEDs

### DIFF
--- a/client.go
+++ b/client.go
@@ -127,7 +127,7 @@ func (c *Client) UpdateZoneLEDs(deviceID, zoneID int, colors []Color) error {
 		return err
 	}
 
-	return c.sendMessage(commandUpdateLEDs, deviceID, cmd)
+	return c.sendMessage(commandUpdateZoneLEDs, deviceID, cmd)
 }
 
 func (c *Client) sendMessage(command, deviceID int, buffer *bytes.Buffer) error {


### PR DESCRIPTION
`client.UpdateZoneLEDs` was sending the command code for `UpdateLEDs`, which was causing it to fail.  Updating it to the right code fixes it.